### PR TITLE
correcting hyperlink to NVD3.js

### DIFF
--- a/output/README.md
+++ b/output/README.md
@@ -1,6 +1,6 @@
 # Output example
 
-An adaptation of the [NVD3.js](http://nv3d.org/) charting library's [Simple Line Chart](http://nvd3.org/ghpages/line.html) example. Demonstrates creating a custom Shiny output binding that uses a JavaScript component.
+An adaptation of the [NVD3.js](http://nvd3.org/) charting library's [Simple Line Chart](http://nvd3.org/ghpages/line.html) example. Demonstrates creating a custom Shiny output binding that uses a JavaScript component.
 
 Run this example by calling:
 


### PR DESCRIPTION
from `http://nv3d.org/` to `http://nvd3.org/`
