### PR TITLE
Update link to NVD3 example

### DIFF
--- a/output/ui.R
+++ b/output/ui.R
@@ -3,7 +3,7 @@ shinyUI(fluidPage(
   fluidRow(
     column(width=6,
       p("This Shiny app is an adaptation of the",
-        a(href="http://nvd3.org/ghpages/line.html", "Simple Line Chart"),
+        a(href="http://nvd3.org/examples/line.html", "Simple Line Chart"),
         "example for the",
         a(href="http://nvd3.org/", "NVD3.js"),
         "JavaScript charting library."


### PR DESCRIPTION
The current link doesn't work, and their page seems to have moved to here: http://nvd3.org/examples/line.html
